### PR TITLE
Removed --default-authentication-plugin flag to fix mysql.plugin tabl…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       MYSQL_PASSWORD: admdimdim
       MYSQL_DATABASE: out_stock
       MYSQL_ROOT_PASSWORD: admdimdim
-    command: --default-authentication-plugin=mysql_native_password
     ports:
       - "3306:3306"
     networks:


### PR DESCRIPTION
…e issue


The --default-authentication-plugin=mysql_native_password flag was causing the "could not open mysql.plugin table" error. Removing this flag resolves the issue.